### PR TITLE
Add func_offset to pydbg

### DIFF
--- a/pydbg.py
+++ b/pydbg.py
@@ -1755,6 +1755,31 @@ class pydbg:
 
         return address
 
+        
+    ####################################################################################################################
+    def func_offset (self, dll, function):
+        '''
+        Utility function that resolves the offset of a given module / function name pair.
+
+        @see: func_offset()
+
+        @type  dll:      String
+        @param dll:      Name of the DLL (case-insensitive)
+        @type  function: String
+        @param function: Name of the function to resolve (case-sensitive)
+
+        @rtype:  DWORD
+        @return: Offset
+        '''
+
+        handle  = kernel32.LoadLibraryA(dll)
+        address = kernel32.GetProcAddress(handle, function)
+        offset = address-handle
+
+        kernel32.FreeLibrary(handle)
+
+        return offset
+
 
     ####################################################################################################################
     def func_resolve_debuggee (self, dll_name, func_name):


### PR DESCRIPTION
func_offset returns the offset of the specified function from the DLL's
base address

func_resolve wasn't working for me in the following use case. func_offset lets me work around the issue.

```
def handler_load_dll(dbg):
    last_dll = dbg.get_system_dll(-1)
    # Wait for the DLL we're looking for ...
    if "ftd2xx.dll".lower() == last_dll.name.lower():
        # Now resolve the address of the function (see note: requires debug symbols)
        write_off = dbg.func_offset(last_dll.name, "FT_Write")
        write_addr = last_dll.base + write_off
        # this didnt work
        # write_addr = dbg.func_resolve(last_dll.name, "FT_Write")
```
